### PR TITLE
Changed http DefaultClient to custom client with timeout

### DIFF
--- a/pkg/deployments/activator/activator.go
+++ b/pkg/deployments/activator/activator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/deislabs/osiris/pkg/healthz"
 	k8s "github.com/deislabs/osiris/pkg/kubernetes"
@@ -30,6 +31,7 @@ type activator struct {
 	deploymentActivations     map[string]*deploymentActivation
 	deploymentActivationsLock sync.Mutex
 	srv                       *http.Server
+	httpClient                *http.Client
 }
 
 func NewActivator(kubeClient kubernetes.Interface) Activator {
@@ -57,6 +59,9 @@ func NewActivator(kubeClient kubernetes.Interface) Activator {
 		},
 		appsByHost:            map[string]*app{},
 		deploymentActivations: map[string]*deploymentActivation{},
+		httpClient: &http.Client{
+			Timeout: time.Minute * 1,
+		},
 	}
 	a.servicesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: a.syncService,

--- a/pkg/deployments/activator/request_handling.go
+++ b/pkg/deployments/activator/request_handling.go
@@ -113,7 +113,7 @@ func (a *activator) handleRequest(
 			a.returnError(w, http.StatusServiceUnavailable)
 			return
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := a.httpClient.Do(req)
 		if err != nil {
 			glog.Errorf("Error proxying request to reactivated application: %s", err)
 			a.returnError(w, http.StatusServiceUnavailable)


### PR DESCRIPTION
http/net DefaultClient has an indefinite timeout which may cause the go-routine to lock in case the target pod is hanging.

This change uses a custom http client with a 1min timeout.