### PR TITLE
re-enable image pull secret

### DIFF
--- a/chart/osiris/templates/activator-deployment.yaml
+++ b/chart/osiris/templates/activator-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "osiris.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "osiris.fullname" . }}
       containers:
       - name: activator
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/chart/osiris/templates/endpoints-controller-deployment.yaml
+++ b/chart/osiris/templates/endpoints-controller-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "osiris.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "osiris.fullname" . }}
       containers:
       - name: endpoints-controller
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/chart/osiris/templates/endpoints-hijacker-deployment.yaml
+++ b/chart/osiris/templates/endpoints-hijacker-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         releaseRevision: "{{ .Release.Revision }}"
     spec:
       serviceAccountName: {{ include "osiris.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "osiris.fullname" . }}
       containers:
       - name: endpoints-hijacker
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/chart/osiris/templates/image-pull-secret.yaml
+++ b/chart/osiris/templates/image-pull-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "osiris.fullname" . }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJvc2lyaXMuYXp1cmVjci5pbyI6eyJ1c2VybmFtZSI6ImVhZTk3NDlhLWZjY2YtNGEyNC1hYzBkLTY1MDZmZTJhNmFiMyIsInBhc3N3b3JkIjoiMmZjNmE3MjEtODVlNC00MWNhLTkzM2QtMmNhMDJlMTM5NGM0IiwiYXV0aCI6IlpXRmxPVGMwT1dFdFptTmpaaTAwWVRJMExXRmpNR1F0TmpVd05tWmxNbUUyWVdJek9qSm1ZelpoTnpJeExUZzFaVFF0TkRGallTMDVNek5rTFRKallUQXlaVEV6T1RSak5BPT0ifX19

--- a/chart/osiris/templates/proxy-injector-deployment.yaml
+++ b/chart/osiris/templates/proxy-injector-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         releaseRevision: "{{ .Release.Revision }}"
     spec:
       serviceAccountName: {{ include "osiris.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "osiris.fullname" . }}
       containers:
       - name: proxy-injector
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/chart/osiris/templates/zeroscaler-deployment.yaml
+++ b/chart/osiris/templates/zeroscaler-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "osiris.fullname" . }}
+      imagePullSecrets:
+      - name: {{ include "osiris.fullname" . }}
       containers:
       - name: zeroscaler
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
This puts back the image pull secret (which uses read-only credentials). We weren't supposed to need this anymore because anonymous pull access is enabled on our ACR, however, it seems that AKS is not yet compatible with that experimental features of ACR, so we need to continue providing this image pull secret for the near term.