### PR TITLE
cleanup unused deps from Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,14 +25,6 @@
 #   unused-packages = true
 
 [[constraint]]
-  name = "github.com/prometheus/client_golang"
-  version = "0.9.0-pre1"
-
-[[constraint]]
-  branch = "addlog"
-  name = "github.com/prometheus/common"
-
-[[constraint]]
   name = "k8s.io/kubernetes"
   version = "1.12.2"
 


### PR DESCRIPTION
Osiris is no longer using `prometheus/common` or `prometheus/client_golang`.

Since their imports don't exist in the code base,  `dep`automatically disregards them. This change should be safe.