### PR TITLE
Allow per-deployment metrics check interval

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -483,6 +483,7 @@
     "github.com/kelseyhightower/envconfig",
     "github.com/phayes/freeport",
     "github.com/satori/go.uuid",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "golang.org/x/net/http/httpguts",
     "golang.org/x/net/http2",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the Helm chart and thei
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `zeroscaler.metricsCheckInterval` | The interval in which the zeroScaler would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. | `150` |
+| `zeroscaler.metricsCheckInterval` | The interval in which the zeroScaler would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. Note that this can also be set on a per-deployment basis, with an annotation. | `150` |
 
 Example of installation with Helm and a custom configuration:
 
@@ -178,6 +178,7 @@ The following table lists the supported annotations for Kubernetes `Deployments`
 | ---------- | ----------- | ------- |
 | `osiris.deislabs.io/enabled` | Enable Osiris for this deployment. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
 | `osiris.deislabs.io/minReplicas` | The minimum number of replicas to set on the deployment when Osiris will scale up. If you set `2`, Osiris will scale the deployment from `0` to `2` replicas directly. Osiris won't collect metrics from deployments which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1` |
+| `osiris.deislabs.io/metricsCheckInterval` | The interval in which Osiris would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. Note that this value override the global value defined by the `zeroscaler.metricsCheckInterval` Helm value. | _value of the `zeroscaler.metricsCheckInterval` Helm value_ |
 
 #### Service Annotations
 

--- a/example/hello-osiris.yaml
+++ b/example/hello-osiris.yaml
@@ -45,6 +45,7 @@ metadata:
   annotations:
     osiris.deislabs.io/enabled: "true"
     osiris.deislabs.io/minReplicas: "1"
+    osiris.deislabs.io/metricsCheckInterval: "120" # seconds
 spec:
   replicas: 1
   selector:

--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -145,6 +145,13 @@ func (z *zeroscaler) ensureMetricsCollection(deployment *appsv1.Deployment) {
 			metricsCheckInterval = z.cfg.MetricsCheckInterval
 		}
 		if metricsCheckInterval <= 0 {
+			glog.Warningf(
+				"Invalid custom metrics check interval value %d in deployment %s,"+
+					" falling back to the default value of %d seconds",
+				metricsCheckInterval,
+				deployment.Name,
+				z.cfg.MetricsCheckInterval,
+			)
 			metricsCheckInterval = z.cfg.MetricsCheckInterval
 		}
 		glog.Infof(

--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -136,8 +136,9 @@ func (z *zeroscaler) ensureMetricsCollection(deployment *appsv1.Deployment) {
 		)
 		if err != nil {
 			glog.Warningf(
-				"Invalid custom metrics check interval value in deployment %s,"+
-					" falling back to the default value of %d seconds; error: %s",
+				"There was an error getting custom metrics check interval value "+
+					"in deployment %s, falling back to the default value of %d "+
+					"seconds; error: %s",
 				deployment.Name,
 				z.cfg.MetricsCheckInterval,
 				err,

--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -131,17 +131,23 @@ func (z *zeroscaler) ensureMetricsCollection(deployment *appsv1.Deployment) {
 		if ok {
 			collector.stop()
 		}
+		metricsCheckInterval := k8s.GetMetricsCheckInterval(
+			deployment.Annotations,
+			z.cfg.MetricsCheckInterval,
+		)
 		glog.Infof(
-			"Using new metrics collector for deployment %s in namespace %s",
+			"Using new metrics collector for deployment %s in namespace %s "+
+				"with metrics check interval of %d seconds",
 			deployment.Name,
 			deployment.Namespace,
+			metricsCheckInterval,
 		)
 		collector := newMetricsCollector(
 			z.kubeClient,
 			deployment.Name,
 			deployment.Namespace,
 			selector,
-			time.Duration(z.cfg.MetricsCheckInterval)*time.Second,
+			time.Duration(metricsCheckInterval)*time.Second,
 		)
 		go func() {
 			collector.run(z.ctx)

--- a/pkg/deployments/zeroscaler/zeroscaler.go
+++ b/pkg/deployments/zeroscaler/zeroscaler.go
@@ -131,10 +131,22 @@ func (z *zeroscaler) ensureMetricsCollection(deployment *appsv1.Deployment) {
 		if ok {
 			collector.stop()
 		}
-		metricsCheckInterval := k8s.GetMetricsCheckInterval(
+		metricsCheckInterval, err := k8s.GetMetricsCheckInterval(
 			deployment.Annotations,
-			z.cfg.MetricsCheckInterval,
 		)
+		if err != nil {
+			glog.Warningf(
+				"Invalid custom metrics check interval value in deployment %s,"+
+					" falling back to the default value of %d seconds; error: %s",
+				deployment.Name,
+				z.cfg.MetricsCheckInterval,
+				err,
+			)
+			metricsCheckInterval = z.cfg.MetricsCheckInterval
+		}
+		if metricsCheckInterval <= 0 {
+			metricsCheckInterval = z.cfg.MetricsCheckInterval
+		}
 		glog.Infof(
 			"Using new metrics collector for deployment %s in namespace %s "+
 				"with metrics check interval of %d seconds",

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -1,8 +1,13 @@
 package kubernetes
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
+)
+
+const (
+	metricsCheckIntervalAnnotationName = "osiris.deislabs.io/metricsCheckInterval"
 )
 
 // ResourceIsOsirisEnabled checks the annotations to see if the
@@ -37,19 +42,24 @@ func GetMinReplicas(annotations map[string]string, defaultVal int32) int32 {
 
 // GetMetricsCheckInterval gets the interval in which the zeroScaler would
 // repeatedly track the pod http request metrics. The value is the number
-// of seconds of the interval. If it fails to do so, it returns the default
-// value instead.
-func GetMetricsCheckInterval(
-	annotations map[string]string,
-	defaultVal int,
-) int {
-	val, ok := annotations["osiris.deislabs.io/metricsCheckInterval"]
+// of seconds of the interval. If it fails to do so, it returns an error.
+func GetMetricsCheckInterval(annotations map[string]string) (int, error) {
+	if len(annotations) == 0 {
+		return 0, nil
+	}
+	val, ok := annotations[metricsCheckIntervalAnnotationName]
 	if !ok {
-		return defaultVal
+		return 0, nil
 	}
 	metricsCheckInterval, err := strconv.Atoi(val)
 	if err != nil {
-		return defaultVal
+		return 0, fmt.Errorf("invalid int value '%s' for '%s' annotation: %s",
+			val, metricsCheckIntervalAnnotationName, err)
 	}
-	return metricsCheckInterval
+	if metricsCheckInterval <= 0 {
+		return 0, fmt.Errorf("metricsCheckInterval should be positive, "+
+			"'%d' is not a valid value",
+			metricsCheckInterval)
+	}
+	return metricsCheckInterval, nil
 }

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -34,3 +34,22 @@ func GetMinReplicas(annotations map[string]string, defaultVal int32) int32 {
 	}
 	return int32(minReplicas)
 }
+
+// GetMetricsCheckInterval gets the interval in which the zeroScaler would
+// repeatedly track the pod http request metrics. The value is the number
+// of seconds of the interval. If it fails to do so, it returns the default
+// value instead.
+func GetMetricsCheckInterval(
+	annotations map[string]string,
+	defaultVal int,
+) int {
+	val, ok := annotations["osiris.deislabs.io/metricsCheckInterval"]
+	if !ok {
+		return defaultVal
+	}
+	metricsCheckInterval, err := strconv.Atoi(val)
+	if err != nil {
+		return defaultVal
+	}
+	return metricsCheckInterval
+}

--- a/pkg/kubernetes/osiris_test.go
+++ b/pkg/kubernetes/osiris_test.go
@@ -113,3 +113,44 @@ func TestGetMinReplicas(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMetricsCheckInterval(t *testing.T) {
+	testcases := []struct {
+		name           string
+		annotations    map[string]string
+		expectedResult int
+	}{
+		{
+			name: "map with metrics check interval entry",
+			annotations: map[string]string{
+				"osiris.deislabs.io/metricsCheckInterval": "60",
+			},
+			expectedResult: 60,
+		},
+		{
+			name: "map with no metrics check interval entry",
+			annotations: map[string]string{
+				"osiris.deislabs.io/notmetricsCheckInterval": "60",
+			},
+			expectedResult: 150,
+		},
+		{
+			name: "map with invalid metrics check interval entry",
+			annotations: map[string]string{
+				"osiris.deislabs.io/metricsCheckInterval": "invalid",
+			},
+			expectedResult: 150,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetMetricsCheckInterval(test.annotations, 150)
+			if actual != test.expectedResult {
+				t.Errorf(
+					"expected GetMetricsCheckInterval to return %d, but got %d",
+					test.expectedResult, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add support for a new annotation `osiris.deislabs.io/metricsCheckInterval` on deployments,
to override the default metricsCheckInterval on a per-deployment basis.

I kept the same name and unit (seconds) to be consistent.