### PR TITLE
Add support for deployments initially scaled to zero

### DIFF
--- a/pkg/endpoints/controller/endpoints_manager.go
+++ b/pkg/endpoints/controller/endpoints_manager.go
@@ -98,6 +98,9 @@ func (e *endpointsManager) run(ctx context.Context) {
 		)
 	}()
 	e.podsInformer.Run(ctx.Done())
+	// force an initial sync of the endpoints for deployments that are initially
+	// scaled to 0, and for which we won't see Pod events.
+	e.syncEndpoints()
 }
 
 func (e *endpointsManager) stop() {


### PR DESCRIPTION
When using a deployment initially scaled to zero replicas, Osiris won't automatically scale it up when needed.
This is because the associated service is not updated with the right endpoints until there is a least 1 pod event.

To fix it I just added an initial call to the `syncEndpoints` func when running the endpoints manager, so that the service will be initially configured with Osiris activator endpoint.