### PR TITLE
Document global config and supported annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ helm install osiris/osiris-edge \
   --devel
 ```
 
+### Configure Osiris
+
+Osiris global configuration is minimal - because most of it will be done by the users
+with annotations on the Kubernetes resources.
+
+The following table lists the configurable parameters of the Helm chart and their default values.
+
+Parameter | Description | Default 
+--------- | ----------- | -------
+`zeroscaler.metricsCheckInterval` | The interval in which the zeroScaler would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. | `150`
+
 ## Usage
 
 Osiris will not affect the normal behavior of any Kubernetes resource without
@@ -142,6 +153,25 @@ spec:
     app: my-app
   # ...
 ```
+
+### Configuration
+
+Most of Osiris configuration is done with Kubernetes annotations.
+
+The following table lists the configurable annotations for each Kubernetes resource and their default values.
+
+Kind | Annotation | Description | Default 
+---- | ---------- | ----------- | -------
+`Deployment` | `osiris.deislabs.io/enabled` | Enable Osiris for this deployment. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled)
+`Deployment` | `osiris.deislabs.io/minReplicas` | The minimum number of replicas to set on the deployment when Osiris will scale up. If you set `2`, Osiris will scale the deployment from `0` to `2` replicas directly. Osiris won't collect metrics from deployments which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1`
+`Service` | `osiris.deislabs.io/enabled` | Enable Osiris for this service. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled)
+`Service` | `osiris.deislabs.io/deployment` | Name of the deployment which is behind this service. This is required to map the service with its deployment. | _no value_
+`Service` | `osiris.deislabs.io/loadBalancerHostname` | Map requests coming from a specific hostname to this service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/loadBalancerHostname-1`, `osiris.deislabs.io/loadBalancerHostname-2`, ... | _no value_
+`Service` | `osiris.deislabs.io/ingressHostname` | Map requests coming from a specific hostname to this service. If you use an ingress in front of your service, this is required to create a link between the ingress and the service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/ingressHostname-1`, `osiris.deislabs.io/ingressHostname-2`, ... | _no value_
+`Service` | `osiris.deislabs.io/ingressDefaultPort` | Custom service port when the request comes from an ingress. Default behaviour if there are more than 1 port on the service, is to look for a port named `http`, and fallback to the port `80`. Set this if you have multiple ports and using a non-standard port with a non-standard name. | _no value_
+`Service` | `osiris.deislabs.io/tlsPort` | Custom port for TLS-secured requests. Default behaviour if there are more than 1 port on the service, is to look for a port named `https`, and fallback to the port `443`. Set this if you have multiple ports and using a non-standard TLS port with a non-standard name. | _no value_
+
+Note that you might see an `osiris.deislabs.io/selector` annotation - this is for internal use only, and you shouldn't try to set/update or delete it.
 
 ### Demo
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Prerequisites:
 * [Helm](https://docs.helm.sh/using_helm/#installing-helm) (v2.11.0 or greater)
 * A running Kubernetes cluster.
 
-### Install Osiris
+### Installation
 
 Osiris' Helm chart is hosted in an
 [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/),
@@ -81,7 +81,9 @@ helm repo add osiris https://osiris.azurecr.io/helm/v1/repo \
 ```
 
 Installation requires use of the `--devel` flag to indicate pre-release versions
-of the specified chart are eligible for download and installation:
+of the specified chart are eligible for download and installation. The following
+command install the latest version of Osiris with the default values for all
+options - see the next section for all available installation options.
 
 ```
 helm install osiris/osiris-edge \
@@ -90,16 +92,26 @@ helm install osiris/osiris-edge \
   --devel
 ```
 
-### Configure Osiris
+#### Installation Options
 
 Osiris global configuration is minimal - because most of it will be done by the users
 with annotations on the Kubernetes resources.
 
 The following table lists the configurable parameters of the Helm chart and their default values.
 
-Parameter | Description | Default 
---------- | ----------- | -------
-`zeroscaler.metricsCheckInterval` | The interval in which the zeroScaler would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. | `150`
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `zeroscaler.metricsCheckInterval` | The interval in which the zeroScaler would repeatedly track the pod http request metrics. The value is the number of seconds of the interval. | `150` |
+
+Example of installation with Helm and a custom configuration:
+
+```
+helm install osiris/osiris-edge \
+  --name osiris \
+  --namespace osiris-system \
+  --devel \
+  --set zeroscaler.metricsCheckInterval=600
+```
 
 ## Usage
 
@@ -156,20 +168,29 @@ spec:
 
 ### Configuration
 
-Most of Osiris configuration is done with Kubernetes annotations.
+Most of Osiris configuration is done with Kubernetes annotations - as seen in the Usage section.
 
-The following table lists the configurable annotations for each Kubernetes resource and their default values.
+#### Deployment Annotations
 
-Kind | Annotation | Description | Default 
----- | ---------- | ----------- | -------
-`Deployment` | `osiris.deislabs.io/enabled` | Enable Osiris for this deployment. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled)
-`Deployment` | `osiris.deislabs.io/minReplicas` | The minimum number of replicas to set on the deployment when Osiris will scale up. If you set `2`, Osiris will scale the deployment from `0` to `2` replicas directly. Osiris won't collect metrics from deployments which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1`
-`Service` | `osiris.deislabs.io/enabled` | Enable Osiris for this service. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled)
-`Service` | `osiris.deislabs.io/deployment` | Name of the deployment which is behind this service. This is required to map the service with its deployment. | _no value_
-`Service` | `osiris.deislabs.io/loadBalancerHostname` | Map requests coming from a specific hostname to this service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/loadBalancerHostname-1`, `osiris.deislabs.io/loadBalancerHostname-2`, ... | _no value_
-`Service` | `osiris.deislabs.io/ingressHostname` | Map requests coming from a specific hostname to this service. If you use an ingress in front of your service, this is required to create a link between the ingress and the service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/ingressHostname-1`, `osiris.deislabs.io/ingressHostname-2`, ... | _no value_
-`Service` | `osiris.deislabs.io/ingressDefaultPort` | Custom service port when the request comes from an ingress. Default behaviour if there are more than 1 port on the service, is to look for a port named `http`, and fallback to the port `80`. Set this if you have multiple ports and using a non-standard port with a non-standard name. | _no value_
-`Service` | `osiris.deislabs.io/tlsPort` | Custom port for TLS-secured requests. Default behaviour if there are more than 1 port on the service, is to look for a port named `https`, and fallback to the port `443`. Set this if you have multiple ports and using a non-standard TLS port with a non-standard name. | _no value_
+The following table lists the supported annotations for Kubernetes `Deployments` and their default values.
+
+| Annotation | Description | Default |
+| ---------- | ----------- | ------- |
+| `osiris.deislabs.io/enabled` | Enable Osiris for this deployment. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.deislabs.io/minReplicas` | The minimum number of replicas to set on the deployment when Osiris will scale up. If you set `2`, Osiris will scale the deployment from `0` to `2` replicas directly. Osiris won't collect metrics from deployments which have more than `minReplicas` replicas - to avoid useless collections of metrics. | `1` |
+
+#### Service Annotations
+
+The following table lists the supported annotations for Kubernetes `Services` and their default values.
+
+| Annotation | Description | Default |
+| ---------- | ----------- | ------- |
+| `osiris.deislabs.io/enabled` | Enable Osiris for this service. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.deislabs.io/deployment` | Name of the deployment which is behind this service. This is required to map the service with its deployment. | _no value_ |
+| `osiris.deislabs.io/loadBalancerHostname` | Map requests coming from a specific hostname to this service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/loadBalancerHostname-1`, `osiris.deislabs.io/loadBalancerHostname-2`, ... | _no value_ |
+| `osiris.deislabs.io/ingressHostname` | Map requests coming from a specific hostname to this service. If you use an ingress in front of your service, this is required to create a link between the ingress and the service. Note that if you have multiple hostnames, you can set them with different annotations, using `osiris.deislabs.io/ingressHostname-1`, `osiris.deislabs.io/ingressHostname-2`, ... | _no value_ |
+| `osiris.deislabs.io/ingressDefaultPort` | Custom service port when the request comes from an ingress. Default behaviour if there are more than 1 port on the service, is to look for a port named `http`, and fallback to the port `80`. Set this if you have multiple ports and using a non-standard port with a non-standard name. | _no value_ |
+| `osiris.deislabs.io/tlsPort` | Custom port for TLS-secured requests. Default behaviour if there are more than 1 port on the service, is to look for a port named `https`, and fallback to the port `443`. Set this if you have multiple ports and using a non-standard TLS port with a non-standard name. | _no value_ |
 
 Note that you might see an `osiris.deislabs.io/selector` annotation - this is for internal use only, and you shouldn't try to set/update or delete it.
 


### PR DESCRIPTION
Document the chart values that affect the global configuration, and all supported annotations.

Depending on which PRs got merged first between this one, and #38 or #39 I'll update the latest ones with the missing documentation.