### PR TITLE
Rename the annotation used to inject the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ spec:
       labels:
         app: nginx
       annotations:
-        osiris.deislabs.io/enabled: "true"
+        osiris.deislabs.io/injectProxy: "true"
     # ...
   # ...
 ```
@@ -192,7 +192,7 @@ The following table lists the supported annotations for Kubernetes `Deployments`
 
 | Annotation | Description | Default |
 | ---------- | ----------- | ------- |
-| `osiris.deislabs.io/enabled` | Enable the metrics collecting proxy sidecar container to be injected into this pod. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
+| `osiris.deislabs.io/injectProxy` | Inject a transparent proxy as a sidecar container into this pod. This is _required_ for metrics collection. Allowed values: `y`, `yes`, `true`, `on`, `1`. | _no value_ (= disabled) |
 
 #### Service Annotations
 

--- a/example/hello-osiris.yaml
+++ b/example/hello-osiris.yaml
@@ -56,7 +56,7 @@ spec:
       labels:
         app: hello-osiris
       annotations:
-        osiris.deislabs.io/enabled: "true"
+        osiris.deislabs.io/injectProxy: "true"
     spec:
       containers:
       - name: hello-osiris

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -8,13 +8,24 @@ import (
 
 const (
 	osirisEnabledAnnotationName        = "osiris.deislabs.io/enabled"
+	injectProxyAnnotationName          = "osiris.deislabs.io/injectProxy"
 	metricsCheckIntervalAnnotationName = "osiris.deislabs.io/metricsCheckInterval"
 )
 
 // ResourceIsOsirisEnabled checks the annotations to see if the
 // kube resource is enabled for osiris or not.
 func ResourceIsOsirisEnabled(annotations map[string]string) bool {
-	enabled, ok := annotations[osirisEnabledAnnotationName]
+	return annotationBooleanValue(annotations, osirisEnabledAnnotationName)
+}
+
+// PodIsEligibleForProxyInjection checks the annotations to see if the
+// pod is eligible for proxy injection or not.
+func PodIsEligibleForProxyInjection(annotations map[string]string) bool {
+	return annotationBooleanValue(annotations, injectProxyAnnotationName)
+}
+
+func annotationBooleanValue(annotations map[string]string, key string) bool {
+	enabled, ok := annotations[key]
 	if !ok {
 		return false
 	}

--- a/pkg/metrics/proxy/injector/pod_patch.go
+++ b/pkg/metrics/proxy/injector/pod_patch.go
@@ -40,7 +40,7 @@ func (i *injector) getPodPatchOperations(
 		req.UserInfo,
 	)
 
-	if !kubernetes.ResourceIsOsirisEnabled(pod.Annotations) ||
+	if !kubernetes.PodIsEligibleForProxyInjection(pod.Annotations) ||
 		(podContainsProxyInitContainer(&pod) && podContainsProxyContainer(&pod)) {
 		return nil, nil
 	}


### PR DESCRIPTION
Following #47 here, let's rename the annotation used to inject the proxy in the pods:

- previous annotation key: `osiris.deislabs.io/enabled`
- new annotation key: `osiris.deislabs.io/injectProxy`

so that we can avoid confusion between the deployments and pods annotations