### PR TITLE
Ensure updates to metricsCheckInterval are taken into account

### DIFF
--- a/pkg/deployments/zeroscaler/zeroscaler_test.go
+++ b/pkg/deployments/zeroscaler/zeroscaler_test.go
@@ -1,0 +1,72 @@
+package zeroscaler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestShouldUpdateCollector(t *testing.T) {
+	testcases := []struct {
+		name                    string
+		collector               *metricsCollector
+		newSelector             labels.Selector
+		newMetricsCheckInterval time.Duration
+		expectedResult          bool
+	}{
+		{
+			name: "same selector and metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Everything(),
+			newMetricsCheckInterval: 5 * time.Second,
+			expectedResult:          false,
+		},
+		{
+			name: "same selector but different metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Everything(),
+			newMetricsCheckInterval: 10 * time.Second,
+			expectedResult:          true,
+		},
+		{
+			name: "different selector but same metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Nothing(),
+			newMetricsCheckInterval: 5 * time.Second,
+			expectedResult:          true,
+		},
+		{
+			name: "different selector and metricsCheckInterval",
+			collector: &metricsCollector{
+				selector:             labels.Everything(),
+				metricsCheckInterval: 5 * time.Second,
+			},
+			newSelector:             labels.Nothing(),
+			newMetricsCheckInterval: 10 * time.Second,
+			expectedResult:          true,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			actual := shouldUpdateCollector(
+				test.collector,
+				test.newSelector,
+				test.newMetricsCheckInterval,
+			)
+
+			assert.Equal(t, test.expectedResult, actual)
+		})
+	}
+}

--- a/pkg/kubernetes/osiris.go
+++ b/pkg/kubernetes/osiris.go
@@ -1,15 +1,14 @@
 package kubernetes
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
 
 const (
 	IgnoredPathsAnnotationName         = "osiris.deislabs.io/ignoredPaths"
+	MetricsCheckIntervalAnnotationName = "osiris.deislabs.io/metricsCheckInterval"
 	osirisEnabledAnnotationName        = "osiris.deislabs.io/enabled"
-	metricsCheckIntervalAnnotationName = "osiris.deislabs.io/metricsCheckInterval"
 )
 
 // ResourceIsOsirisEnabled checks the annotations to see if the
@@ -40,28 +39,4 @@ func GetMinReplicas(annotations map[string]string, defaultVal int32) int32 {
 		return defaultVal
 	}
 	return int32(minReplicas)
-}
-
-// GetMetricsCheckInterval gets the interval in which the zeroScaler would
-// repeatedly track the pod http request metrics. The value is the number
-// of seconds of the interval. If it fails to do so, it returns an error.
-func GetMetricsCheckInterval(annotations map[string]string) (int, error) {
-	if len(annotations) == 0 {
-		return 0, nil
-	}
-	val, ok := annotations[metricsCheckIntervalAnnotationName]
-	if !ok {
-		return 0, nil
-	}
-	metricsCheckInterval, err := strconv.Atoi(val)
-	if err != nil {
-		return 0, fmt.Errorf("invalid int value '%s' for '%s' annotation: %s",
-			val, metricsCheckIntervalAnnotationName, err)
-	}
-	if metricsCheckInterval <= 0 {
-		return 0, fmt.Errorf("metricsCheckInterval should be positive, "+
-			"'%d' is not a valid value",
-			metricsCheckInterval)
-	}
-	return metricsCheckInterval, nil
 }

--- a/pkg/kubernetes/osiris_test.go
+++ b/pkg/kubernetes/osiris_test.go
@@ -2,9 +2,6 @@ package kubernetes
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResourceIsOsirisEnabled(t *testing.T) {
@@ -113,85 +110,6 @@ func TestGetMinReplicas(t *testing.T) {
 					"expected GetMinReplicas to return %d, but got %d",
 					test.expectedResult, actual)
 			}
-		})
-	}
-}
-
-func TestGetMetricsCheckInterval(t *testing.T) {
-	testcases := []struct {
-		name           string
-		annotations    map[string]string
-		expectedResult int
-		expectedError  string
-	}{
-		{
-			name:           "nil map",
-			annotations:    nil,
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name:           "empty map",
-			annotations:    map[string]string{},
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name: "map with no metrics check interval entry",
-			annotations: map[string]string{
-				"whatever": "60",
-			},
-			expectedResult: 0,
-			expectedError:  "",
-		},
-		{
-			name: "map with invalid metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.deislabs.io/metricsCheckInterval": "invalid",
-			},
-			expectedResult: 0,
-			expectedError: "invalid int value 'invalid' for " +
-				"'osiris.deislabs.io/metricsCheckInterval' annotation: " +
-				"strconv.Atoi: parsing \"invalid\": invalid syntax",
-		},
-		{
-			name: "map with negative metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.deislabs.io/metricsCheckInterval": "-1",
-			},
-			expectedResult: 0,
-			expectedError: "metricsCheckInterval should be positive, " +
-				"'-1' is not a valid value",
-		},
-		{
-			name: "map with zero metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.deislabs.io/metricsCheckInterval": "0",
-			},
-			expectedResult: 0,
-			expectedError: "metricsCheckInterval should be positive, " +
-				"'0' is not a valid value",
-		},
-		{
-			name: "map with valid metrics check interval entry",
-			annotations: map[string]string{
-				"osiris.deislabs.io/metricsCheckInterval": "60",
-			},
-			expectedResult: 60,
-			expectedError:  "",
-		},
-	}
-
-	for _, test := range testcases {
-		t.Run(test.name, func(t *testing.T) {
-			actual, err := GetMetricsCheckInterval(test.annotations)
-			if len(test.expectedError) > 0 {
-				require.EqualError(t, err, test.expectedError, "")
-			} else {
-				require.NoError(t, err)
-			}
-
-			assert.Equal(t, test.expectedResult, actual)
 		})
 	}
 }


### PR DESCRIPTION
The first implementation of the per-deployment metricsCheckInterval never took into account updates of the annotation value.
The new one read the annotation value and compare it to the current one to decide if the metrics collector should be recreated or not.