### PR TITLE
Fix the admission hook configuration

### DIFF
--- a/chart/osiris/templates/proxy-injector-webhook-config.yaml
+++ b/chart/osiris/templates/proxy-injector-webhook-config.yaml
@@ -37,15 +37,6 @@ webhooks:
     caBundle: {{ b64enc $ca.Cert }}
   rules:
   - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    resources:
-    - deployments
-    operations:
-    - CREATE
-    - UPDATE
-  - apiGroups:
     - ""
     apiVersions:
     - v1


### PR DESCRIPTION
because we're not mutating the deployments anymore, we shouldn't have a rule in the webhook config for it.

Got the following error while trying to create a deployment:

```
$ kubectl create deployment app --image=...
Error from server (InternalError): Internal error occurred: admission webhook "proxy-injector.osiris.deislabs.io" denied the request: Invalid kind for review: AdmissionReview
```

Manually editing the webhook config to remove the deployment rule fixed the issue.