### PR TITLE
upgrade to newer helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ base-go-job: &base-go-job
 
 base-docker-job: &base-docker-job
   docker:
-    - image: quay.io/deis/acr-publishing-tools:v0.1.0
+    - image: quay.io/deis/acr-publishing-tools:v0.2.0
   environment:
     SKIP_DOCKER: true
   working_directory: /go/src/github.com/deislabs/osiris

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifneq ($(SKIP_DOCKER),true)
 		-v $(PROJECT_ROOT):/go/src/$(BASE_PACKAGE_NAME) \
 		-w /go/src/$(BASE_PACKAGE_NAME) $(DEV_IMAGE)
 
-	HELM_IMAGE := quay.io/deis/acr-publishing-tools:v0.1.0
+	HELM_IMAGE := quay.io/deis/acr-publishing-tools:v0.2.0
 	DOCKER_HELM_CMD := docker run \
 		--rm \
 		-v $(PROJECT_ROOT):/go/src/$(BASE_PACKAGE_NAME) \


### PR DESCRIPTION
Fixes #59 (hopefully). This should always quote the value of the `appVersion` field when packaging a chart. I cannot guarantee that ACR will preserve those quotes when it adds the packaged chart to its index, but 🤞 .